### PR TITLE
Fix system's locale for unit tests

### DIFF
--- a/src/test/java/io/github/andrelugomes/DemoSpringBootWebApp.java
+++ b/src/test/java/io/github/andrelugomes/DemoSpringBootWebApp.java
@@ -1,9 +1,12 @@
 package io.github.andrelugomes;
 
 import io.github.andrelugomes.annotation.ServiceValidation;
+import java.util.Locale;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
@@ -11,9 +14,14 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.NotNull;
 
 @SpringBootApplication
-public class DemoSpringBootWebApp {
+public class DemoSpringBootWebApp implements ApplicationListener<ApplicationReadyEvent> {
     public static void main(String[] args) {
         SpringApplication.run(DemoSpringBootWebApp.class, args);
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent applicationReadyEvent) {
+        Locale.setDefault(Locale.ENGLISH);
     }
 }
 


### PR DESCRIPTION
This commit fixes the following error when running the unit tests on a machine with a locale other than *en*:

```
java.lang.AssertionError:
Expecting:
 <"não pode ser nulo">
to be equal to:
 <"may not be null">
ignoring case considerations

	at io.github.andrelugomes.ServiceValidationTest.shouldVerifyConstraintViolationsOnCatch(ServiceValidationTest.java:122)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
```

I'm not 100% happy with the setUp/tearDown approach but I do not remember having to deal with locale-dependent tests in the past, so if you happen to have a better option for this I'm all ears.