### PR TITLE
Add library-specific exception with a full view of violations

### DIFF
--- a/src/main/java/io/github/andrelugomes/exception/ServiceValidationErrorCollection.java
+++ b/src/main/java/io/github/andrelugomes/exception/ServiceValidationErrorCollection.java
@@ -1,0 +1,16 @@
+package io.github.andrelugomes.exception;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class ServiceValidationErrorCollection extends HashMap<String, List<String>> {
+
+    public void addError(String valuePath, String errorMessage) {
+        if (!containsKey(valuePath)) {
+            put(valuePath, new ArrayList<>());
+        }
+        get(valuePath).add(errorMessage);
+    }
+
+}

--- a/src/main/java/io/github/andrelugomes/exception/ServiceValidationException.java
+++ b/src/main/java/io/github/andrelugomes/exception/ServiceValidationException.java
@@ -1,0 +1,20 @@
+package io.github.andrelugomes.exception;
+
+
+/**
+ * Thrown when one or more parameters of
+ * an annotated method is invalid, i.e.
+ * is null or do not pass JSR-303 validation.
+ */
+public class ServiceValidationException extends RuntimeException {
+
+    private ServiceValidationErrorCollection errors;
+
+    public ServiceValidationException(ServiceValidationErrorCollection errors) {
+        this.errors = errors;
+    }
+
+    public ServiceValidationErrorCollection getErrors() {
+        return errors;
+    }
+}

--- a/src/test/java/io/github/andrelugomes/DemoSpringBootWebApp.java
+++ b/src/test/java/io/github/andrelugomes/DemoSpringBootWebApp.java
@@ -66,6 +66,8 @@ interface MyService {
 
     DTO doSomething(DTO dto);
 
+    void doSomethingElse(DTO dto1, DTO dto2, DTO dto3);
+
     String getStringByName(String name);
 
     Long getLong(Long number, String string);
@@ -82,6 +84,10 @@ class MyServiceImpl implements MyService {
     public DTO doSomething(final DTO dto) {
         return dto;
     }
+
+    @Override
+    @ServiceValidation
+    public void doSomethingElse(DTO dto1, DTO dto2, DTO dto3) {}
 
     @Override
     @ServiceValidation

--- a/src/test/java/io/github/andrelugomes/ServiceValidationTest.java
+++ b/src/test/java/io/github/andrelugomes/ServiceValidationTest.java
@@ -30,8 +30,8 @@ public class ServiceValidationTest {
         } catch (ServiceValidationException ex) {
             ServiceValidationErrorCollection errors = ex.getErrors();
             assertThat(errors).hasSize(1);
-            assertThat(errors.get("args[0].text")).hasSize(1);
-            assertThat(errors.get("args[0].text").get(0)).isEqualToIgnoringCase("may not be null");
+            assertThat(errors.get("DTO.text")).hasSize(1);
+            assertThat(errors.get("DTO.text").get(0)).isEqualToIgnoringCase("may not be null");
         }
     }
 
@@ -43,8 +43,8 @@ public class ServiceValidationTest {
         } catch (ServiceValidationException ex) {
             ServiceValidationErrorCollection errors = ex.getErrors();
             assertThat(errors).hasSize(1);
-            assertThat(errors.get("args[0]")).hasSize(1);
-            assertThat(errors.get("args[0]").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
+            assertThat(errors.get("DTO")).hasSize(1);
+            assertThat(errors.get("DTO").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
         }
     }
 
@@ -93,8 +93,8 @@ public class ServiceValidationTest {
         } catch (ServiceValidationException ex) {
             ServiceValidationErrorCollection errors = ex.getErrors();
             assertThat(errors).hasSize(1);
-            assertThat(errors.get("args[0]")).hasSize(1);
-            assertThat(errors.get("args[0]").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
+            assertThat(errors.get("String")).hasSize(1);
+            assertThat(errors.get("String").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
         }
     }
 
@@ -106,8 +106,8 @@ public class ServiceValidationTest {
         } catch (ServiceValidationException ex) {
             ServiceValidationErrorCollection errors = ex.getErrors();
             assertThat(errors).hasSize(1);
-            assertThat(errors.get("args[0]")).hasSize(1);
-            assertThat(errors.get("args[0]").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
+            assertThat(errors.get("Long")).hasSize(1);
+            assertThat(errors.get("Long").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
         }
     }
 
@@ -122,10 +122,10 @@ public class ServiceValidationTest {
         } catch (ServiceValidationException ex) {
             ServiceValidationErrorCollection errors = ex.getErrors();
             assertThat(errors).hasSize(2);
-            assertThat(errors.get("args[0]")).hasSize(1);
-            assertThat(errors.get("args[0]").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
-            assertThat(errors.get("args[1].text")).hasSize(1);
-            assertThat(errors.get("args[1].text").get(0)).isEqualToIgnoringCase("may not be null");
+            assertThat(errors.get("DTO")).hasSize(1);
+            assertThat(errors.get("DTO").get(0)).isEqualToIgnoringCase(ServiceValidationAspectImpl.NULLSAFE_VIOLATION_MESSAGE);
+            assertThat(errors.get("DTO.text")).hasSize(1);
+            assertThat(errors.get("DTO.text").get(0)).isEqualToIgnoringCase("may not be null");
         }
     }
 }


### PR DESCRIPTION
Before this commit the validation would stop right after the first violation discovery. Now there is an exception encapsulating a full view of everything wrong with the parameters, improving
logging and user reporting capabilities.

Related to #3.